### PR TITLE
Use title case for Agent Receipts link text

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ Dutch-born, Amsterdam-raised, Sydney-detoured, Wellington-settled.
 
 I'm a Senior Backend Developer at [Forsyth Barr](https://www.forsythbarr.co.nz/) on the Tempo team, where we build the backend services and microservices behind their retail investment platform. Before New Zealand, I spent five years at [Atlassian](https://www.atlassian.com) — first in Amsterdam, then Sydney.
 
-I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in AI agents and developer tooling. I'm building [agent-receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents.
+I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in AI agents and developer tooling. I'm building [Agent Receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents.
 
 AWS (ECS Fargate, DynamoDB, EventBridge), TypeScript, distributed systems. Background in cloud infrastructure, container orchestration, and infrastructure-as-code.
 


### PR DESCRIPTION
## Summary
- Changed link text from "agent-receipts" to "Agent Receipts" for better SEO — matches how users would search for the project name

## Test plan
- [x] Verify the link renders correctly on the site