### PR TITLE
Add Plausible analytics

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html{{ with .Site.LanguageCode }} lang="{{ . }}"{{ end }}>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta content="{{ delimit .Site.Params.Keywords ", " }}" name="keywords">
+<meta content="{{ .Site.Params.Author }}" name="author">
+<meta property="og:title" content="{{ $isHomePage := eq .Title .Site.Title }}{{ .Title }}{{ if eq $isHomePage false }} - {{ .Site.Title }}{{ end }}">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:description" content="{{ .Site.Params.Description }}">
+<meta property="og:type" content="website" />
+<title>{{ .Title }}{{ if eq .IsHome false }} | {{ .Site.Title }}{{ end }}</title>
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
+<link rel="shortcut icon" href="{{ .Site.BaseURL }}/wave.ico">
+<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+{{ with .Site.Params.highlight.style }}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/{{ . }}.min.css">
+{{ else }}
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/default.min.css" integrity="sha256-Zd1icfZ72UBmsId/mUcagrmN7IN5Qkrvh75ICHIQVTk=" crossorigin="anonymous" />
+{{ end }}
+{{ if not .Site.IsServer }}
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-WKnCByjanGZTw3vXUysKS.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>
+{{ end }}


### PR DESCRIPTION
Adds privacy-friendly [Plausible](https://plausible.io) analytics to the site.

## Approach
- Overrides the theme's `header.html` at the project level (`layouts/partials/header.html`), leaving `themes/hucore` untouched — the standard Hugo override path.
- Injects Plausible's hashed script snippet before `</head>`.

## Notes
- Wrapped in `{{ if not .Site.IsServer }}` so the tracker only loads in production builds, not during local `hugo server` dev — keeps dev traffic out of the stats.
- Make sure `jongerius.solutions` is registered in the Plausible dashboard before merging.