### PR TITLE
Fix deploy: use hugo.IsServer

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
 {{ else }}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/default.min.css" integrity="sha256-Zd1icfZ72UBmsId/mUcagrmN7IN5Qkrvh75ICHIQVTk=" crossorigin="anonymous" />
 {{ end }}
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
 <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-WKnCByjanGZTw3vXUysKS.js"></script>
 <script>


### PR DESCRIPTION
The Plausible header partial used `.Site.IsServer`, which was removed in Hugo (CI runs v0.163) and broke the production build (PR #13 deploy failed).

Switches to `hugo.IsServer`, the current replacement. Same behaviour: the tracker only loads in production builds, not local `hugo server`.