### PR TITLE
Replace deprecated languageCode with locale

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://jongerius.solutions"
-languageCode = "en-us"
+locale = "en-us"
 title = "Otto Jongerius"
 
 theme = "hucore"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html{{ with .Site.LanguageCode }} lang="{{ . }}"{{ end }}>
+<html{{ with .Site.Language.Locale }} lang="{{ . }}"{{ end }}>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta content="{{ delimit .Site.Params.Keywords ", " }}" name="keywords">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
 {{ else }}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/default.min.css" integrity="sha256-Zd1icfZ72UBmsId/mUcagrmN7IN5Qkrvh75ICHIQVTk=" crossorigin="anonymous" />
 {{ end }}
-{{ if not .Site.IsServer }}
+{{ if not hugo.IsServer }}
 <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-WKnCByjanGZTw3vXUysKS.js"></script>
 <script>


### PR DESCRIPTION
Clears the Hugo deprecation warnings seen in the deploy logs:
- `languageCode` config key → `locale` (deprecated in v0.158.0).
- `.Site.LanguageCode` → `.Site.Language.Locale` in the header partial.

No visible change — `<html lang="en-us">` renders the same.