### PR TITLE
Add auto-generated llms.txt for AI crawlers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,14 @@ title = "Otto Jongerius"
 theme = "hucore"
 copyright = "&copy; 2026 Otto Jongerius | <a href=\"https://gohugo.io\" target=\"_blank\">Hugo</a>"
 
+[outputs]
+home = ["HTML", "RSS", "LLMS"]
+
+[outputFormats.LLMS]
+mediaType = "text/plain"
+baseName = "llms"
+isPlainText = true
+
 [taxonomies]
 tag = "tags"
 category = "categories"

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,11 @@
+# {{ .Site.Title }}
+
+> {{ .Site.Params.Description }}
+
+{{ .Site.Params.author }} — {{ .Site.BaseURL }}
+
+## Posts
+
+{{ range (where .Site.RegularPages "Section" "post").ByDate.Reverse -}}
+- [{{ .Title }}]({{ .Permalink }}): {{ .Summary | plainify | chomp | truncate 200 }}
+{{ end -}}


### PR DESCRIPTION
Adds an [`llms.txt`](https://llmstxt.org/) at the site root — a markdown map of the site for LLMs / AI crawlers (distinct from robots.txt and the SEO meta work). **Verified with a local Hugo v0.163 build** (CI's version) — clean.

## Approach
Generated from content via a Hugo custom output format, so it stays current as posts are published — no static file to go stale.
- `config.toml`: registers an `LLMS` output format (`text/plain`, `baseName = "llms"`) and adds it to the home page outputs alongside HTML and RSS.
- `layouts/index.llms.txt`: renders title, description, author, and a newest-first list of posts with truncated summaries.

## Output (`/llms.txt`)
```
# Otto Jongerius

> Backend developer, open source contributor, AI agent tinkerer

Otto Jongerius — https://jongerius.solutions/

## Posts

- [My OpenClaw Agent's Shell Commands, On the Record](.../agent-receipts-openclaw-v0-trial/): A few weeks back I showed cryptographic receipts…
- ...
```

Independent of #16 — can merge in either order.