### PR TITLE
content: per-post SEO descriptions, social images, Obsigna links, bio update

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ Dutch-born, Amsterdam-raised, Sydney-detoured, Wellington-settled.
 
 I'm a Senior Backend Developer at [Forsyth Barr](https://www.forsythbarr.co.nz/) on the Tempo team, where we build the backend services and microservices behind their retail investment platform. Before New Zealand, I spent five years at [Atlassian](https://www.atlassian.com) — first in Amsterdam, then Sydney.
 
-I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in AI agents and developer tooling. I'm building [Agent Receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents — and [Obsigna](https://obsigna.dev), the tooling that implements it.
+I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in agentic engineering and AI accountability. I'm building [Agent Receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents — and [Obsigna](https://obsigna.dev), the tooling that implements it.
 
 AWS (Lambda, ECS Fargate, DynamoDB, EventBridge), TypeScript, serverless, distributed systems. Background in cloud infrastructure, container orchestration, and infrastructure-as-code.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,9 +8,9 @@ Dutch-born, Amsterdam-raised, Sydney-detoured, Wellington-settled.
 
 I'm a Senior Backend Developer at [Forsyth Barr](https://www.forsythbarr.co.nz/) on the Tempo team, where we build the backend services and microservices behind their retail investment platform. Before New Zealand, I spent five years at [Atlassian](https://www.atlassian.com) — first in Amsterdam, then Sydney.
 
-I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in AI agents and developer tooling. I'm building [Agent Receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents.
+I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in AI agents and developer tooling. I'm building [Agent Receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents — and [Obsigna](https://obsigna.dev), the tooling that implements it.
 
-AWS (ECS Fargate, DynamoDB, EventBridge), TypeScript, distributed systems. Background in cloud infrastructure, container orchestration, and infrastructure-as-code.
+AWS (Lambda, ECS Fargate, DynamoDB, EventBridge), TypeScript, serverless, distributed systems. Background in cloud infrastructure, container orchestration, and infrastructure-as-code.
 
 Outside of work, I run a film club focused on auteur cinema.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ Dutch-born, Amsterdam-raised, Sydney-detoured, Wellington-settled.
 
 I'm a Senior Backend Developer at [Forsyth Barr](https://www.forsythbarr.co.nz/) on the Tempo team, where we build the backend services and microservices behind their retail investment platform. Before New Zealand, I spent five years at [Atlassian](https://www.atlassian.com) — first in Amsterdam, then Sydney.
 
-I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in agentic engineering and AI accountability. I'm building [Agent Receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents — and [Obsigna](https://obsigna.dev), the tooling that implements it.
+I've spoken at tech events in London, Tokyo, Sydney, and Wellington. These days I'm especially interested in agentic engineering and AI auditability. I'm building [Agent Receipts](https://agentreceipts.ai/) ([GitHub](https://github.com/agent-receipts)) — accountability infrastructure for AI agents — and [Obsigna](https://obsigna.dev), the tooling that implements it.
 
 AWS (Lambda, ECS Fargate, DynamoDB, EventBridge), TypeScript, serverless, distributed systems. Background in cloud infrastructure, container orchestration, and infrastructure-as-code.
 

--- a/content/post/agent-receipts-openclaw-v0-trial.md
+++ b/content/post/agent-receipts-openclaw-v0-trial.md
@@ -5,6 +5,8 @@ categories = ["AI", "agents"]
 tags = ["AI agents", "agent-receipts", "OpenClaw", "cryptography", "audit trail", "open source"]
 draft = false
 author = "Otto Jongerius"
+description = "Putting the Agent Receipts OpenClaw plugin to the test: every tool call my agent runs, classified, signed, and recorded as a verifiable receipt."
+image = "/images/post/max-shannon-verification.png"
 +++
 
 A few weeks back I [showed cryptographic receipts for AI agent actions](/post/auditing-github-mcp-agent-receipts/) — through an MCP signing proxy, watching every call to the GitHub MCP server. The proxy works for what flows through MCP. Plenty doesn't.
@@ -130,5 +132,6 @@ That'll do.
 
 - Plugin repo: [github.com/agent-receipts/openclaw](https://github.com/agent-receipts/openclaw)
 - Protocol spec + SDKs: [github.com/agent-receipts/ar](https://github.com/agent-receipts/ar)
+- Tooling: [Obsigna](https://obsigna.dev)
 - Docs: [agentreceipts.ai](https://agentreceipts.ai)
 - If you want the mechanics: [OpenClaw Plugin Deep Dive](https://agentreceipts.ai/blog/openclaw-plugin-deep-dive/)

--- a/content/post/agent-receipts-openclaw-v0-trial.md
+++ b/content/post/agent-receipts-openclaw-v0-trial.md
@@ -131,7 +131,7 @@ That'll do.
 ---
 
 - Plugin repo: [github.com/agent-receipts/openclaw](https://github.com/agent-receipts/openclaw)
-- Protocol spec + SDKs: [github.com/agent-receipts/ar](https://github.com/agent-receipts/ar)
+- Protocol spec + SDKs: [github.com/agent-receipts/obsigna](https://github.com/agent-receipts/obsigna)
 - Tooling: [Obsigna](https://obsigna.dev)
 - Docs: [agentreceipts.ai](https://agentreceipts.ai)
 - If you want the mechanics: [OpenClaw Plugin Deep Dive](https://agentreceipts.ai/blog/openclaw-plugin-deep-dive/)

--- a/content/post/auditing-github-mcp-agent-receipts.md
+++ b/content/post/auditing-github-mcp-agent-receipts.md
@@ -142,7 +142,7 @@ Each row is a W3C Verifiable Credential stored on disk. Here's the core of one �
 ```
 
 (The full receipt also includes W3C `@context`, issuer and principal DIDs — currently
-placeholders while the [DID method strategy](https://github.com/agent-receipts/ar/issues/46)
+placeholders while the [DID method strategy](https://github.com/agent-receipts/obsigna/issues/46)
 is finalised — and standard VC envelope fields.)
 
 The `parameters_hash` is a SHA-256 of the RFC 8785 canonical JSON of the tool call
@@ -179,8 +179,8 @@ double-dash flags (`--db`) when the binary uses single-dash Go flags (`-db`).
 
 So I filed both bugs via the proxy:
 
-- [#109 — tool name not stored in receipt, action.type always unknown](https://github.com/agent-receipts/ar/issues/109) — fixed in v0.3.3 of the proxy
-- [#101 — Docs: CLI reference shows double-dash flags but binary uses single-dash](https://github.com/agent-receipts/ar/issues/101)
+- [#109 — tool name not stored in receipt, action.type always unknown](https://github.com/agent-receipts/obsigna/issues/109) — fixed in v0.3.3 of the proxy
+- [#101 — Docs: CLI reference shows double-dash flags but binary uses single-dash](https://github.com/agent-receipts/obsigna/issues/101)
 
 Those GitHub API calls — `create_issue`, `update_issue` — have signed receipts from
 the GitHub MCP server running through the proxy. The bug reports about Agent Receipts
@@ -214,7 +214,7 @@ This is early days — proxy v0.3.3, SDKs v0.3.0. A few things I hit during the 
 
 **Placeholder DIDs.** The issuer shows as `did:agent:mcp-proxy` and principal as
 `did:user:unknown`. These are placeholders — the DID method strategy is being worked
-out in [ADR-0007](https://github.com/agent-receipts/ar/issues/46). For now they're
+out in [ADR-0007](https://github.com/agent-receipts/obsigna/issues/46). For now they're
 labels, not resolvable identifiers.
 
 **Fine-grained PATs don't work for org write access.** GitHub's org-level policy for
@@ -232,13 +232,13 @@ not just GitHub.
 go install github.com/agent-receipts/ar/mcp-proxy/cmd/mcp-proxy@v0.3.3
 ```
 
-Check the [releases page](https://github.com/agent-receipts/ar/releases) for the
+Check the [releases page](https://github.com/agent-receipts/obsigna/releases) for the
 latest version.
 
 Full walkthrough: [Auditing Your GitHub MCP Server with Agent Receipts](https://agentreceipts.ai/mcp-proxy/overview/)
 
 The spec, SDKs, and proxy are all in the monorepo at
-[github.com/agent-receipts/ar](https://github.com/agent-receipts/ar), and the
+[github.com/agent-receipts/obsigna](https://github.com/agent-receipts/obsigna), and the
 tooling lives at [Obsigna](https://obsigna.dev).
 
 ---
@@ -249,19 +249,19 @@ This is an open protocol and we're building it in the open. Here are some concre
 areas where input would be especially valuable:
 
 **Security:**
-- [Audit secret redaction patterns for edge cases](https://github.com/agent-receipts/ar/issues/150)
-- [Supply chain security: binary signing and verification](https://github.com/agent-receipts/ar/issues/151)
-- [Enforce restrictive file permissions on signing keys](https://github.com/agent-receipts/ar/issues/156)
-- [Document threat model and trust boundaries](https://github.com/agent-receipts/ar/issues/155)
+- [Audit secret redaction patterns for edge cases](https://github.com/agent-receipts/obsigna/issues/150)
+- [Supply chain security: binary signing and verification](https://github.com/agent-receipts/obsigna/issues/151)
+- [Enforce restrictive file permissions on signing keys](https://github.com/agent-receipts/obsigna/issues/156)
+- [Document threat model and trust boundaries](https://github.com/agent-receipts/obsigna/issues/155)
 
 **Protocol design:**
-- [Hash server responses in receipts, not just requests](https://github.com/agent-receipts/ar/issues/153)
-- [Define receipt schema stability and versioning policy](https://github.com/agent-receipts/ar/issues/154)
-- [Receipt export to external systems (SIEM/syslog/OTLP)](https://github.com/agent-receipts/ar/issues/152)
+- [Hash server responses in receipts, not just requests](https://github.com/agent-receipts/obsigna/issues/153)
+- [Define receipt schema stability and versioning policy](https://github.com/agent-receipts/obsigna/issues/154)
+- [Receipt export to external systems (SIEM/syslog/OTLP)](https://github.com/agent-receipts/obsigna/issues/152)
 
 **Developer experience:**
-- [`mcp-proxy init` command for guided setup](https://github.com/agent-receipts/ar/issues/148)
-- [Document proxy crash/timeout behaviour](https://github.com/agent-receipts/ar/issues/149)
+- [`mcp-proxy init` command for guided setup](https://github.com/agent-receipts/obsigna/issues/148)
+- [Document proxy crash/timeout behaviour](https://github.com/agent-receipts/obsigna/issues/149)
 
 If you're working on MCP tooling, agent governance, or verifiable credentials — or if
 you just want to poke holes in the design — pick an issue and jump in.

--- a/content/post/auditing-github-mcp-agent-receipts.md
+++ b/content/post/auditing-github-mcp-agent-receipts.md
@@ -5,6 +5,8 @@ categories = ["AI", "agents"]
 tags = ["AI agents", "MCP", "cryptography", "open source", "GitHub", "audit trail"]
 draft = false
 author = "Otto Jongerius"
+description = "I built a signing proxy that gives every MCP tool call my AI agent makes a cryptographically signed, tamper-evident receipt — then used it to audit itself."
+image = "/images/post/shinkansen-agent-receipts.jpg"
 +++
 
 Somewhere between Kyoto temples I shipped a signing proxy for [Agent Receipts](https://agentreceipts.ai) — an open protocol that gives every AI agent action a cryptographically signed audit trail. The idea is simple: when an agent acts on your behalf, you should be able to prove what happened. Not just logs. Proof.
@@ -236,7 +238,8 @@ latest version.
 Full walkthrough: [Auditing Your GitHub MCP Server with Agent Receipts](https://agentreceipts.ai/mcp-proxy/overview/)
 
 The spec, SDKs, and proxy are all in the monorepo at
-[github.com/agent-receipts/ar](https://github.com/agent-receipts/ar).
+[github.com/agent-receipts/ar](https://github.com/agent-receipts/ar), and the
+tooling lives at [Obsigna](https://obsigna.dev).
 
 ---
 

--- a/content/post/your-ai-agent-just-sent-an-email.md
+++ b/content/post/your-ai-agent-just-sent-an-email.md
@@ -5,6 +5,7 @@ categories = ["AI", "agents"]
 tags = ["AI agents", "accountability", "open source", "MCP", "cryptography"]
 draft = false
 author = "Otto Jongerius"
+description = "When an AI agent acts on your behalf, can you prove what it did? Agent Receipts gives every action a cryptographically signed, tamper-evident record."
 +++
 
 Last week, I asked an AI agent to clean up some files in a project directory. It did a great job — renamed a few things, deleted some stale configs, updated a README. I know this because I watched it happen in my terminal.


### PR DESCRIPTION
Content polish across the bio and posts. **Verified with a local Hugo v0.163 build** — clean.

## Per-post SEO
- Hand-written `description` front matter on all three posts (was auto-derived) — sharper search snippets.
- `image` front matter for social cards: `shinkansen-agent-receipts.jpg` (auditing) and `max-shannon-verification.png` (OpenClaw). The email post's only image is an SVG (poor social-card support), so it falls back to the site default `frontier.jpg`.

## Obsigna links
Everything linked the spec (`agentreceipts.ai`) but never the tooling. Added [Obsigna](https://obsigna.dev), worded as spec-vs-tooling, on the homepage bio, the auditing post (MCP proxy), and the OpenClaw post resources.

## Repo rename: ar → obsigna
The `agent-receipts/ar` repo was renamed to `agent-receipts/obsigna`. Updated all GitHub **web links** (repo, issues, releases) accordingly.
- **Left the two `go install github.com/agent-receipts/ar/mcp-proxy/...` commands unchanged** — the module's `go.mod` still declares `github.com/agent-receipts/ar/mcp-proxy`, so the rename redirect handles them; changing the import path would make `go install` fail with a path mismatch.

## Bio
- Added `Lambda` and `serverless` to the AWS/tech-stack line.
- Reframed interests: 'AI agents and developer tooling' → 'agentic engineering and AI accountability'.