### PR TITLE
ci: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: latest
           extended: true
@@ -30,7 +30,7 @@ jobs:
         run: hugo
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: public
 
@@ -43,4 +43,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v3
@@ -30,7 +30,7 @@ jobs:
         run: hugo
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: public
 
@@ -43,4 +43,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Resolves the Node 20 deprecation warnings in the deploy logs (GitHub forces Node 24 on Actions **June 16, 2026**, removes Node 20 Sept 16) and hardens the workflow against supply-chain risk by pinning every action to an immutable commit SHA.

## Version bumps (all confirmed running `node24`)
- `actions/checkout` v4 → **v5.0.1**
- `actions/upload-pages-artifact` v3 → **v5.0.0**
- `actions/deploy-pages` v4 → **v5.0.0**

## SHA pinning
Every `uses:` is now pinned to a full 40-char commit SHA with the human-readable version in a trailing comment (Dependabot/Renovate still track these). Mutable tags like `v5` can be force-moved by a compromised maintainer; a SHA can't.
- `actions/checkout@93cb6ef…` # v5.0.1
- `peaceiris/actions-hugo@2752ce1…` # v3.2.1 (also pinned, even though third-party Hugo installer isn't affected by the Node 20 change)
- `actions/upload-pages-artifact@fc324d3…` # v5.0.0
- `actions/deploy-pages@cd2ce8f…` # v5.0.0

Workflow changes can't be verified locally — they'll exercise on merge.